### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.10 AS builder
+
+WORKDIR /go/src/github.com/rrreeeyyy/prometheus-http-sd
+
+COPY vendor vendor/
+COPY main.go .
+
+RUN env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -o /prometheus-http-sd main.go
+
+FROM alpine:edge
+RUN apk add --update --no-cache ca-certificates
+COPY --from=builder /prometheus-http-sd /prometheus-http-sd
+USER nobody
+ENTRYPOINT ["/prometheus-http-sd"]


### PR DESCRIPTION
Adds a simple dockerfile for building the app. It is written so that it works by default with the prometheus docker image with no changes required.