### PR TITLE
Add support for multiple API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,17 @@ docker pull rrreeeyyy/prometheus-http-sd
 
 ## Usage
 
-```
-./prometheus-http-sd --api.url="http://api.example.com/service_discovery.json" --output.file=/path/to/http_sd.json --refresh.interval=60
-```
+- Run a single API endpoint
+
+    ```
+    ./prometheus-http-sd --api.url="http://api.example.com/service_discovery.json" --output.file=/path/to/http_sd.json --refresh.interval=60
+    ```
+
+- Run multiple API endpoints
+
+    ```
+    ./prometheus-http-sd --api.url="http://api.example.com/foo_service_discovery.json" --output.file=/path/to/http_foo_sd.json --api.url="http://api.example.com/bar_service_discovery.json" --output.file=/path/to/http_bar_sd.json --refresh.interval=60
+    ```
 
 ## HTTP API format
 


### PR DESCRIPTION
If merging this patch, promethus-http-sd will supports multiple API endpoints.

- use multiple pairs of `--api.url` and` --output.file` options
- stop if the number of options differs between `--api.url` and `--output.file`

Usage:

```
./prometheus-http-sd --api.url="http://example.com/test1.json" --output.file="/path/to/test1.json" \
    --api.url="http://example.com/test2.json" --output.file="/path/to/test2.json"
```

resolves #2 